### PR TITLE
Store V1 wsdl documents in fixtures and use them as default wsdl documents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (0.2.10)
+    conduit-sprint (0.2.11)
       StreetAddress
       conduit (~> 0.6.0)
       excon (~> 0.21.0)
@@ -21,15 +21,15 @@ GEM
     akami (1.2.2)
       gyoku (>= 0.4.0)
       nokogiri
-    aws-sdk (2.0.26)
-      aws-sdk-resources (= 2.0.26)
-    aws-sdk-core (2.0.26)
+    aws-sdk (2.0.28)
+      aws-sdk-resources (= 2.0.28)
+    aws-sdk-core (2.0.28)
       builder (~> 3.0)
       jmespath (~> 1.0)
       multi_json (~> 1.0)
       multi_xml (~> 0.5)
-    aws-sdk-resources (2.0.26)
-      aws-sdk-core (= 2.0.26)
+    aws-sdk-resources (2.0.28)
+      aws-sdk-core (= 2.0.28)
     builder (3.2.2)
     conduit (0.6.0)
       activesupport

--- a/lib/conduit/sprint/actions/base.rb
+++ b/lib/conduit/sprint/actions/base.rb
@@ -74,7 +74,11 @@ module Conduit::Driver::Sprint
     end
 
     def wsdl
-      "https://#{gateway}/#{self.class.wsdl_service}?wsdl"
+      if @options.key?(:gateway)
+        "https://#{gateway}/#{self.class.wsdl_service}?wsdl"
+      else
+        File.expand_path("spec/fixtures/wsdl/#{self.class.wsdl_service}.wsdl")
+      end
     end
 
     private

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '0.2.10'
+    VERSION = '0.2.11'
   end
 end

--- a/spec/fixtures/wsdl/QueryCsaService/v1.wsdl
+++ b/spec/fixtures/wsdl/QueryCsaService/v1.wsdl
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/QueryCsa/v1/QueryCsa.wsdl" targetNamespace="http://integration.sprint.com/eai/services/QueryCsa/v1/QueryCsa.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetails.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/QueryCsa/v1/QueryCsaEnvelope.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/queryCsa/v2/queryCsaV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd7.xsd" namespace="http://integration.sprint.com/interfaces/queryLocationInfo/v1/queryLocationInfo.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="faultmessage">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetails.xsd"/></wsdl:message>
+<wsdl:message name="faultmessage2">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="queryCsaRequest">
+<wsdl:part name="body" element="xsns:queryCsa" xmlns:xsns="http://integration.sprint.com/interfaces/QueryCsa/v1/QueryCsaEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryCsaResponse">
+<wsdl:part name="body" element="xsns:queryCsaResponse" xmlns:xsns="http://integration.sprint.com/interfaces/QueryCsa/v1/QueryCsaEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryCsaV2">
+<wsdl:part name="body" element="xsns:queryCsaV2" xmlns:xsns="http://integration.sprint.com/interfaces/queryCsa/v2/queryCsaV2.xsd"/></wsdl:message>
+<wsdl:message name="queryCsaV2Response">
+<wsdl:part name="body" element="xsns:queryCsaV2Response" xmlns:xsns="http://integration.sprint.com/interfaces/queryCsa/v2/queryCsaV2.xsd"/></wsdl:message>
+<wsdl:message name="queryLocationInfo">
+<wsdl:part name="body" element="xsns:queryLocationInfo" xmlns:xsns="http://integration.sprint.com/interfaces/queryLocationInfo/v1/queryLocationInfo.xsd"/></wsdl:message>
+<wsdl:message name="queryLocationInfoResponse">
+<wsdl:part name="body" element="xsns:queryLocationInfoResponse" xmlns:xsns="http://integration.sprint.com/interfaces/queryLocationInfo/v1/queryLocationInfo.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="QueryCsaPortType">
+<wsdl:operation name="QueryCsa">
+<wsdl:input name="QueryCsaRequest" message="ns0:queryCsaRequest"/>
+<wsdl:output name="QueryCsaResponse" message="ns0:queryCsaResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="QueryCsaV2">
+<wsdl:input name="QueryCsaV2Request" message="ns0:queryCsaV2"/>
+<wsdl:output name="QueryCsaV2Response" message="ns0:queryCsaV2Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessage2"/></wsdl:operation>
+<wsdl:operation name="QueryLocationInfo">
+<wsdl:input name="QueryLocationInfoRequest" message="ns0:queryLocationInfo"/>
+<wsdl:output name="QueryLocationInfoResponse" message="ns0:queryLocationInfoResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="QueryCsaBinding" type="ns0:QueryCsaPortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="QueryCsa">
+<soap11:operation soapAction="queryCsa" style="document"/>
+<wsdl:input name="QueryCsaRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryCsaResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QueryCsaV2">
+<soap11:operation soapAction="QueryCsaV2" style="document"/>
+<wsdl:input name="QueryCsaV2Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryCsaV2Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QueryLocationInfo">
+<soap11:operation soapAction="QueryLocationInfo" style="document"/>
+<wsdl:input name="QueryLocationInfoRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryLocationInfoResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="QueryCsaService">
+<wsdl:port name="QueryCsaPort" binding="ns0:QueryCsaBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/QueryCsaService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleDeviceManagementService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleDeviceManagementService/v1.wsdl
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleDeviceManagementService/v1/WholesaleDeviceManagementService.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleDeviceManagementService/v1/WholesaleDeviceManagementService.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/interfaces/manageDevicePhoneOwnership/v1/manageDevicePhoneOwnership.xsd"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleManageDeviceLock/v1/wholesaleManageDeviceLock.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="faultMessage">
+<wsdl:part name="parameters" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="manageDevicePhoneOwnership">
+<wsdl:part name="parameters" element="xsns:manageDevicePhoneOwnership" xmlns:xsns="http://integration.sprint.com/interfaces/manageDevicePhoneOwnership/v1/manageDevicePhoneOwnership.xsd"/></wsdl:message>
+<wsdl:message name="manageDevicePhoneOwnershipResponse">
+<wsdl:part name="parameters" element="xsns:manageDevicePhoneOwnershipResponse" xmlns:xsns="http://integration.sprint.com/interfaces/manageDevicePhoneOwnership/v1/manageDevicePhoneOwnership.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleManageDeviceLock">
+<wsdl:part name="parameters" element="xsns:wholesaleManageDeviceLock" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleManageDeviceLock/v1/wholesaleManageDeviceLock.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleManageDeviceLockResponse">
+<wsdl:part name="parameters" element="xsns:wholesaleManageDeviceLockResponse" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleManageDeviceLock/v1/wholesaleManageDeviceLock.xsd"/></wsdl:message>
+<wsdl:message name="wsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleDeviceManagementServicePortType">
+<wsdl:operation name="ManageDevicePhoneOwnership">
+<wsdl:input name="ManageDevicePhoneOwnershipRequest" message="ns0:manageDevicePhoneOwnership"/>
+<wsdl:output name="ManageDevicePhoneOwnershipResponse" message="ns0:manageDevicePhoneOwnershipResponse"/>
+<wsdl:fault name="fault" message="ns0:faultMessage"/></wsdl:operation>
+<wsdl:operation name="WholesaleManageDeviceLock">
+<wsdl:input name="WholesaleManageDeviceLockRequest" message="ns0:wholesaleManageDeviceLock"/>
+<wsdl:output name="WholesaleManageDeviceLockResponse" message="ns0:wholesaleManageDeviceLockResponse"/>
+<wsdl:fault name="fault" message="ns0:faultMessage"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleDeviceManagementServiceSoapBinding" type="ns0:WholesaleDeviceManagementServicePortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="ManageDevicePhoneOwnership">
+<soap11:operation soapAction="manageDevicePhoneOwnership" style="document"/>
+<wsdl:input name="ManageDevicePhoneOwnershipRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:wsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ManageDevicePhoneOwnershipResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:wsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleManageDeviceLock">
+<soap11:operation soapAction="WholesaleManageDeviceLock" style="document"/>
+<wsdl:input name="WholesaleManageDeviceLockRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:wsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleManageDeviceLockResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:wsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleDeviceManagementService">
+<wsdl:port name="WholesaleDeviceManagementServicePortType" binding="ns0:WholesaleDeviceManagementServiceSoapBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleDeviceManagementService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesalePortMessageService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesalePortMessageService/v1.wsdl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesalePortMessageService/v1/WholesalePortMessageService.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesalePortMessageService/v1/WholesalePortMessageService.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/interfaces/queryPortMessage/v1/queryPortMessage.xsd"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/replyPortOutRequest/v1/replyPortOutRequest.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/resendPortMessage/v1/resendPortMessage.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="queryPortMessageRequest">
+<wsdl:part name="parameters" element="xsns:queryPortMessage" xmlns:xsns="http://integration.sprint.com/interfaces/queryPortMessage/v1/queryPortMessage.xsd"/></wsdl:message>
+<wsdl:message name="queryPortMessageResponse">
+<wsdl:part name="parameters" element="xsns:queryPortMessageResponse" xmlns:xsns="http://integration.sprint.com/interfaces/queryPortMessage/v1/queryPortMessage.xsd"/></wsdl:message>
+<wsdl:message name="replyPortOutRequest">
+<wsdl:part name="parameters" element="xsns:replyPortOutRequest" xmlns:xsns="http://integration.sprint.com/interfaces/replyPortOutRequest/v1/replyPortOutRequest.xsd"/></wsdl:message>
+<wsdl:message name="replyPortOutRequestResponse">
+<wsdl:part name="parameters" element="xsns:replyPortOutRequestResponse" xmlns:xsns="http://integration.sprint.com/interfaces/replyPortOutRequest/v1/replyPortOutRequest.xsd"/></wsdl:message>
+<wsdl:message name="resendPortMessageRequest">
+<wsdl:part name="parameters" element="xsns:resendPortMessage" xmlns:xsns="http://integration.sprint.com/interfaces/resendPortMessage/v1/resendPortMessage.xsd"/></wsdl:message>
+<wsdl:message name="resendPortMessageResponse">
+<wsdl:part name="parameters" element="xsns:resendPortMessageResponse" xmlns:xsns="http://integration.sprint.com/interfaces/resendPortMessage/v1/resendPortMessage.xsd"/></wsdl:message>
+<wsdl:message name="SoapFault">
+<wsdl:part name="fault" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="WSMessageHeader">
+<wsdl:part name="header" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesalePortMessageServicePortType">
+<wsdl:operation name="QueryPortMessage">
+<wsdl:input name="QueryPortMessageRequest" message="ns0:queryPortMessageRequest"/>
+<wsdl:output name="QueryPortMessageResponse" message="ns0:queryPortMessageResponse"/>
+<wsdl:fault name="fault" message="ns0:SoapFault"/></wsdl:operation>
+<wsdl:operation name="ReplyPortOutRequest">
+<wsdl:input name="ReplyPortOutRequestRequest" message="ns0:replyPortOutRequest"/>
+<wsdl:output name="ReplyPortOutRequestResponse" message="ns0:replyPortOutRequestResponse"/>
+<wsdl:fault name="fault" message="ns0:SoapFault"/></wsdl:operation>
+<wsdl:operation name="ResendPortMessage">
+<wsdl:input name="ResendPortMessageRequest" message="ns0:resendPortMessageRequest"/>
+<wsdl:output name="ResendPortMessageResponse" message="ns0:resendPortMessageResponse"/>
+<wsdl:fault name="fault" message="ns0:SoapFault"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesalePortMessageServiceBinding" type="ns0:WholesalePortMessageServicePortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="QueryPortMessage">
+<soap11:operation soapAction="QueryPortMessage" style="document"/>
+<wsdl:input name="QueryPortMessageRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WSMessageHeader" part="header" use="literal"/></wsdl:input>
+<wsdl:output name="QueryPortMessageResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WSMessageHeader" part="header" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ReplyPortOutRequest">
+<soap11:operation soapAction="ReplyPortOutRequest" style="document"/>
+<wsdl:input name="ReplyPortOutRequestRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WSMessageHeader" part="header" use="literal"/></wsdl:input>
+<wsdl:output name="ReplyPortOutRequestResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WSMessageHeader" part="header" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ResendPortMessage">
+<soap11:operation soapAction="ResendPortMessage" style="document"/>
+<wsdl:input name="ResendPortMessageRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WSMessageHeader" part="header" use="literal"/></wsdl:input>
+<wsdl:output name="ResendPortMessageResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WSMessageHeader" part="header" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesalePortMessageService">
+<wsdl:port name="SendPortMessagePortType" binding="ns0:WholesalePortMessageServiceBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesalePortMessageService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleQueryDeviceInfoService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleQueryDeviceInfoService/v1.wsdl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleQueryDeviceInfoService/v1/WholesaleQueryDeviceInfoService.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleQueryDeviceInfoService/v1/WholesaleQueryDeviceInfoService.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleValidateDevice/v1/wholesaleValidateDevice.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="soapFaultV2">
+<wsdl:part name="faultV2" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleValidateDevice">
+<wsdl:part name="parameters" element="xsns:wholesaleValidateDevice" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleValidateDevice/v1/wholesaleValidateDevice.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleValidateDeviceResponse">
+<wsdl:part name="parameters" element="xsns:wholesaleValidateDeviceResponse" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleValidateDevice/v1/wholesaleValidateDevice.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleQueryDeviceInfoServicePortType">
+<wsdl:operation name="WholesaleValidateDevice">
+<wsdl:input name="WholesaleValidateDeviceRequest" message="ns0:wholesaleValidateDevice"/>
+<wsdl:output name="WholesaleValidateDeviceResponse" message="ns0:wholesaleValidateDeviceResponse"/>
+<wsdl:fault name="fault" message="ns0:soapFaultV2"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleQueryDeviceInfoServiceBinding" type="ns0:WholesaleQueryDeviceInfoServicePortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="WholesaleValidateDevice">
+<soap11:operation soapAction="WholesaleValidateDevice" style="document"/>
+<wsdl:input name="WholesaleValidateDeviceRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleValidateDeviceResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleQueryDeviceInfoService">
+<wsdl:port name="WholesaleQueryDeviceInfoServicePortType" binding="ns0:WholesaleQueryDeviceInfoServiceBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleQueryDeviceInfoService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleSubscriptionDetailService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleSubscriptionDetailService/v1.wsdl
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleSubscriptionDetail/v1/WholesaleSubscriptionDetail.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleSubscriptionDetail/v1/WholesaleSubscriptionDetail.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetails.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleQueryCsaStaticIpNgpInfo/v1/wholesaleQueryCsaStaticIpNgpInfoV1.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleQueryPpSocList/v3/wholesaleQueryPpSocListV3.xsd"/>
+<xsd:import schemaLocation="v1.xsd7.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleQuerySubscription/v4/wholesaleQuerySubscriptionV4.xsd"/>
+<xsd:import schemaLocation="v1.xsd8.xsd" namespace="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="faultmessage">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetails.xsd"/></wsdl:message>
+<wsdl:message name="faultmessageV2">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="queryCsaListRequest">
+<wsdl:part name="body" element="xsns:queryCsaList" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryCsaListResponse">
+<wsdl:part name="body" element="xsns:queryCsaListResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryPpSocListRequest">
+<wsdl:part name="body" element="xsns:queryPpSocList" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryPpSocListResponse">
+<wsdl:part name="body" element="xsns:queryPpSocListResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryReservedSubscriptionRequest">
+<wsdl:part name="body" element="xsns:queryReservedSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryReservedSubscriptionResponse">
+<wsdl:part name="body" element="xsns:queryReservedSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="querySubscriptionRequest">
+<wsdl:part name="body" element="xsns:querySubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="querySubscriptionResponse">
+<wsdl:part name="body" element="xsns:querySubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryValidNpaListRequest">
+<wsdl:part name="body" element="xsns:queryValidNpaList" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryValidNpaListResponse">
+<wsdl:part name="body" element="xsns:queryValidNpaListResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionDetail/v1/SubscriptionDetailEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleQueryCsaStaticIpNgpInfoV1">
+<wsdl:part name="body" element="xsns:wholesaleQueryCsaStaticIpNgpInfoV1" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleQueryCsaStaticIpNgpInfo/v1/wholesaleQueryCsaStaticIpNgpInfoV1.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleQueryCsaStaticIpNgpInfoV1Response">
+<wsdl:part name="body" element="xsns:wholesaleQueryCsaStaticIpNgpInfoV1Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleQueryCsaStaticIpNgpInfo/v1/wholesaleQueryCsaStaticIpNgpInfoV1.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleQueryPpSocListV3">
+<wsdl:part name="body" element="xsns:wholesaleQueryPpSocListV3" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleQueryPpSocList/v3/wholesaleQueryPpSocListV3.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleQueryPpSocListV3Response">
+<wsdl:part name="body" element="xsns:wholesaleQueryPpSocListV3Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleQueryPpSocList/v3/wholesaleQueryPpSocListV3.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleQuerySubscriptionV4">
+<wsdl:part name="body" element="xsns:wholesaleQuerySubscriptionV4" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleQuerySubscription/v4/wholesaleQuerySubscriptionV4.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleQuerySubscriptionV4Response">
+<wsdl:part name="body" element="xsns:wholesaleQuerySubscriptionV4Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleQuerySubscription/v4/wholesaleQuerySubscriptionV4.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleSubscriptionDetailPortType">
+<wsdl:operation name="QueryCsaList">
+<wsdl:input name="QueryCsaListRequest" message="ns0:queryCsaListRequest"/>
+<wsdl:output name="QueryCsaListResponse" message="ns0:queryCsaListResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="QueryPpSocList">
+<wsdl:input name="QueryPpSocListRequest" message="ns0:queryPpSocListRequest"/>
+<wsdl:output name="QueryPpSocListResponse" message="ns0:queryPpSocListResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="QueryReservedSubscription">
+<wsdl:input name="QueryReservedSubscriptionRequest" message="ns0:queryReservedSubscriptionRequest"/>
+<wsdl:output name="QueryReservedSubscriptionResponse" message="ns0:queryReservedSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="QuerySubscription">
+<wsdl:input name="QuerySubscriptionRequest" message="ns0:querySubscriptionRequest"/>
+<wsdl:output name="QuerySubscriptionResponse" message="ns0:querySubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="QueryValidNpaList">
+<wsdl:input name="QueryValidNpaListRequest" message="ns0:queryValidNpaListRequest"/>
+<wsdl:output name="QueryValidNpaListResponse" message="ns0:queryValidNpaListResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="WholesaleQueryCsaStaticIpNgpInfoV1">
+<wsdl:input name="WholesaleQueryCsaStaticIpNgpInfoV1Request" message="ns0:wholesaleQueryCsaStaticIpNgpInfoV1"/>
+<wsdl:output name="WholesaleQueryCsaStaticIpNgpInfoV1Response" message="ns0:wholesaleQueryCsaStaticIpNgpInfoV1Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation>
+<wsdl:operation name="WholesaleQueryPpSocListV3">
+<wsdl:input name="WholesaleQueryPpSocListV3Request" message="ns0:wholesaleQueryPpSocListV3"/>
+<wsdl:output name="WholesaleQueryPpSocListV3Response" message="ns0:wholesaleQueryPpSocListV3Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation>
+<wsdl:operation name="WholesaleQuerySubscriptionV4">
+<wsdl:input name="WholesaleQuerySubscriptionV4Request" message="ns0:wholesaleQuerySubscriptionV4"/>
+<wsdl:output name="WholesaleQuerySubscriptionV4Response" message="ns0:wholesaleQuerySubscriptionV4Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleSubscriptionDetailBinding" type="ns0:WholesaleSubscriptionDetailPortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="QueryCsaList">
+<soap11:operation soapAction="queryCsaList" style="document"/>
+<wsdl:input name="QueryCsaListRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryCsaListResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QueryPpSocList">
+<soap11:operation soapAction="queryPpSocList" style="document"/>
+<wsdl:input name="QueryPpSocListRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryPpSocListResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QueryReservedSubscription">
+<soap11:operation soapAction="queryReservedSubscription" style="document"/>
+<wsdl:input name="QueryReservedSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryReservedSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QuerySubscription">
+<soap11:operation soapAction="querySubscription" style="document"/>
+<wsdl:input name="QuerySubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QuerySubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QueryValidNpaList">
+<soap11:operation soapAction="queryValidNpaList" style="document"/>
+<wsdl:input name="QueryValidNpaListRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryValidNpaListResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleQueryCsaStaticIpNgpInfoV1">
+<soap11:operation soapAction="WholesaleQueryCsaStaticIpNgpInfoV1" style="document"/>
+<wsdl:input name="WholesaleQueryCsaStaticIpNgpInfoV1Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleQueryCsaStaticIpNgpInfoV1Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleQueryPpSocListV3">
+<soap11:operation soapAction="WholesaleQueryPpSocListV3" style="document"/>
+<wsdl:input name="WholesaleQueryPpSocListV3Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleQueryPpSocListV3Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleQuerySubscriptionV4">
+<soap11:operation soapAction="WholesaleQuerySubscriptionV4" style="document"/>
+<wsdl:input name="WholesaleQuerySubscriptionV4Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleQuerySubscriptionV4Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleSubscriptionDetailService">
+<wsdl:port name="WholesaleSubscriptionDetailPort" binding="ns0:WholesaleSubscriptionDetailBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleSubscriptionDetailService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleSubscriptionModifyService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleSubscriptionModifyService/v1.wsdl
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleSubscriptionModify/v1/WholesaleSubscriptionModify.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleSubscriptionModify/v1/WholesaleSubscriptionModify.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetails.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleChangeServicePlans/v3/wholesaleChangeServicePlansV3.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="changeServicePlansRequest">
+<wsdl:part name="body" element="xsns:changeServicePlans" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="changeServicePlansResponse">
+<wsdl:part name="body" element="xsns:changeServicePlansResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="expireSubscriptionRequest">
+<wsdl:part name="body" element="xsns:expireSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="expireSubscriptionResponse">
+<wsdl:part name="body" element="xsns:expireSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="faultmessage">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetails.xsd"/></wsdl:message>
+<wsdl:message name="faultmessageV2">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="restoreSubscriptionRequest">
+<wsdl:part name="body" element="xsns:restoreSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="restoreSubscriptionResponse">
+<wsdl:part name="body" element="xsns:restoreSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="suspendSubscriptionRequest">
+<wsdl:part name="body" element="xsns:suspendSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="suspendSubscriptionResponse">
+<wsdl:part name="body" element="xsns:suspendSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscriptionModify/v1/ModifySubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleChangeServicePlansV3">
+<wsdl:part name="body" element="xsns:wholesaleChangeServicePlansV3" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleChangeServicePlans/v3/wholesaleChangeServicePlansV3.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleChangeServicePlansV3Response">
+<wsdl:part name="body" element="xsns:wholesaleChangeServicePlansV3Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleChangeServicePlans/v3/wholesaleChangeServicePlansV3.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleSubscriptionModifyPortType">
+<wsdl:operation name="ChangeServicePlans">
+<wsdl:input name="ChangeServicePlansRequest" message="ns0:changeServicePlansRequest"/>
+<wsdl:output name="ChangeServicePlansResponse" message="ns0:changeServicePlansResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ExpireSubscription">
+<wsdl:input name="ExpireSubscriptionRequest" message="ns0:expireSubscriptionRequest"/>
+<wsdl:output name="ExpireSubscriptionResponse" message="ns0:expireSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="RestoreSubscription">
+<wsdl:input name="RestoreSubscriptionRequest" message="ns0:restoreSubscriptionRequest"/>
+<wsdl:output name="RestoreSubscriptionResponse" message="ns0:restoreSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="SuspendSubscription">
+<wsdl:input name="SuspendSubscriptionRequest" message="ns0:suspendSubscriptionRequest"/>
+<wsdl:output name="SuspendSubscriptionResponse" message="ns0:suspendSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="WholesaleChangeServicePlansV3">
+<wsdl:input name="WholesaleChangeServicePlansV3Request" message="ns0:wholesaleChangeServicePlansV3"/>
+<wsdl:output name="WholesaleChangeServicePlansV3Response" message="ns0:wholesaleChangeServicePlansV3Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleSubscriptionModifyBinding" type="ns0:WholesaleSubscriptionModifyPortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="ChangeServicePlans">
+<soap11:operation soapAction="changeServicePlans" style="document"/>
+<wsdl:input name="ChangeServicePlansRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ChangeServicePlansResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ExpireSubscription">
+<soap11:operation soapAction="expireSubscription" style="document"/>
+<wsdl:input name="ExpireSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ExpireSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="RestoreSubscription">
+<soap11:operation soapAction="restoreSubscription" style="document"/>
+<wsdl:input name="RestoreSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="RestoreSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="SuspendSubscription">
+<soap11:operation soapAction="suspendSubscription" style="document"/>
+<wsdl:input name="SuspendSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="SuspendSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleChangeServicePlansV3">
+<soap11:operation soapAction="WholesaleChangeServicePlansV3" style="document"/>
+<wsdl:input name="WholesaleChangeServicePlansV3Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleChangeServicePlansV3Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleSubscriptionModifyService">
+<wsdl:port name="WholesaleSubscriptionModifyPort" binding="ns0:WholesaleSubscriptionModifyBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleSubscriptionModifyService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleSubscriptionService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleSubscriptionService/v1.wsdl
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleSubscription/v1/WholesaleSubscription.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleSubscription/v1/WholesaleSubscription.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetails.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleActivatePendingSubscription/v4/wholesaleActivatePendingSubscriptionV4.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleActivateSubscription/v4/wholesaleActivateSubscriptionV4.xsd"/>
+<xsd:import schemaLocation="v1.xsd7.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleReserveSubscription/v3/wholesaleReserveSubscriptionV3.xsd"/>
+<xsd:import schemaLocation="v1.xsd8.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleReserveSubscriptionGeoCode/v3/wholesaleReserveSubscriptionGeoCodeV3.xsd"/>
+<xsd:import schemaLocation="v1.xsd9.xsd" namespace="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="activatePendingSubscriptionRequest">
+<wsdl:part name="body" element="xsns:activatePendingSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activatePendingSubscriptionResponse">
+<wsdl:part name="body" element="xsns:activatePendingSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionMsidRequest">
+<wsdl:part name="body" element="xsns:activateSubscriptionMsid" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionMsidResponse">
+<wsdl:part name="body" element="xsns:activateSubscriptionMsidResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionNpaRequest">
+<wsdl:part name="body" element="xsns:activateSubscriptionNpa" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionNpaResponse">
+<wsdl:part name="body" element="xsns:activateSubscriptionNpaResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionNpaWithRsvIdRequest">
+<wsdl:part name="body" element="xsns:activateSubscriptionNpaWithRsvId" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionNpaWithRsvIdResponse">
+<wsdl:part name="body" element="xsns:activateSubscriptionNpaWithRsvIdResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionRequest">
+<wsdl:part name="body" element="xsns:activateSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionResponse">
+<wsdl:part name="body" element="xsns:activateSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionWithRsvIdRequest">
+<wsdl:part name="body" element="xsns:activateSubscriptionWithRsvId" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionWithRsvIdResponse">
+<wsdl:part name="body" element="xsns:activateSubscriptionWithRsvIdResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="faultmessage">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetails.xsd"/></wsdl:message>
+<wsdl:message name="faultmessageV2">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionGeoCodeNpaRequest">
+<wsdl:part name="body" element="xsns:reserveSubscriptionGeoCodeNpa" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionGeoCodeNpaResponse">
+<wsdl:part name="body" element="xsns:reserveSubscriptionGeoCodeNpaResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionGeoCodeRequest">
+<wsdl:part name="body" element="xsns:reserveSubscriptionGeoCode" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionGeoCodeResponse">
+<wsdl:part name="body" element="xsns:reserveSubscriptionGeoCodeResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionNpaRequest">
+<wsdl:part name="body" element="xsns:reserveSubscriptionNpa" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionNpaResponse">
+<wsdl:part name="body" element="xsns:reserveSubscriptionNpaResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionRequest">
+<wsdl:part name="body" element="xsns:reserveSubscription" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionResponse">
+<wsdl:part name="body" element="xsns:reserveSubscriptionResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionWithRsvIdRequest">
+<wsdl:part name="body" element="xsns:reserveSubscriptionWithRsvId" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="reserveSubscriptionWithRsvIdResponse">
+<wsdl:part name="body" element="xsns:reserveSubscriptionWithRsvIdResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSubscription/v1/SubscriptionEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleActivatePendingSubscriptionV4">
+<wsdl:part name="body" element="xsns:wholesaleActivatePendingSubscriptionV4" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleActivatePendingSubscription/v4/wholesaleActivatePendingSubscriptionV4.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleActivatePendingSubscriptionV4Response">
+<wsdl:part name="body" element="xsns:wholesaleActivatePendingSubscriptionV4Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleActivatePendingSubscription/v4/wholesaleActivatePendingSubscriptionV4.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleActivateSubscriptionV4">
+<wsdl:part name="body" element="xsns:wholesaleActivateSubscriptionV4" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleActivateSubscription/v4/wholesaleActivateSubscriptionV4.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleActivateSubscriptionV4Response">
+<wsdl:part name="body" element="xsns:wholesaleActivateSubscriptionV4Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleActivateSubscription/v4/wholesaleActivateSubscriptionV4.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleReserveSubscriptionGeoCodeV3">
+<wsdl:part name="body" element="xsns:wholesaleReserveSubscriptionGeoCodeV3" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleReserveSubscriptionGeoCode/v3/wholesaleReserveSubscriptionGeoCodeV3.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleReserveSubscriptionGeoCodeV3Response">
+<wsdl:part name="body" element="xsns:wholesaleReserveSubscriptionGeoCodeV3Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleReserveSubscriptionGeoCode/v3/wholesaleReserveSubscriptionGeoCodeV3.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleReserveSubscriptionV3">
+<wsdl:part name="body" element="xsns:wholesaleReserveSubscriptionV3" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleReserveSubscription/v3/wholesaleReserveSubscriptionV3.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleReserveSubscriptionV3Response">
+<wsdl:part name="body" element="xsns:wholesaleReserveSubscriptionV3Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleReserveSubscription/v3/wholesaleReserveSubscriptionV3.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleSubscriptionPortType">
+<wsdl:operation name="ActivatePendingSubscription" parameterOrder="body">
+<wsdl:input name="ActivatePendingSubscriptionRequest" message="ns0:activatePendingSubscriptionRequest"/>
+<wsdl:output name="ActivatePendingSubscriptionResponse" message="ns0:activatePendingSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ActivateSubscription">
+<wsdl:input name="ActivateSubscriptionRequest" message="ns0:activateSubscriptionRequest"/>
+<wsdl:output name="ActivateSubscriptionResponse" message="ns0:activateSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionMsid">
+<wsdl:input name="ActivateSubscriptionMsidRequest" message="ns0:activateSubscriptionMsidRequest"/>
+<wsdl:output name="ActivateSubscriptionMsidResponse" message="ns0:activateSubscriptionMsidResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionNpa">
+<wsdl:input name="ActivateSubscriptionNpaRequest" message="ns0:activateSubscriptionNpaRequest"/>
+<wsdl:output name="ActivateSubscriptionNpaResponse" message="ns0:activateSubscriptionNpaResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionNpaWithRsvId">
+<wsdl:input name="ActivateSubscriptionNpaWithRsvIdRequest" message="ns0:activateSubscriptionNpaWithRsvIdRequest"/>
+<wsdl:output name="ActivateSubscriptionNpaWithRsvIdResponse" message="ns0:activateSubscriptionNpaWithRsvIdResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionWithRsvId">
+<wsdl:input name="ActivateSubscriptionWithRsvIdRequest" message="ns0:activateSubscriptionWithRsvIdRequest"/>
+<wsdl:output name="ActivateSubscriptionWithRsvIdResponse" message="ns0:activateSubscriptionWithRsvIdResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ReserveSubscription">
+<wsdl:input name="ReserveSubscriptionRequest" message="ns0:reserveSubscriptionRequest"/>
+<wsdl:output name="ReserveSubscriptionResponse" message="ns0:reserveSubscriptionResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionGeoCode">
+<wsdl:input name="ReserveSubscriptionGeoCodeRequest" message="ns0:reserveSubscriptionGeoCodeRequest"/>
+<wsdl:output name="ReserveSubscriptionGeoCodeResponse" message="ns0:reserveSubscriptionGeoCodeResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionGeoCodeNpa">
+<wsdl:input name="ReserveSubscriptionGeoCodeNpaRequest" message="ns0:reserveSubscriptionGeoCodeNpaRequest"/>
+<wsdl:output name="ReserveSubscriptionGeoCodeNpaResponse" message="ns0:reserveSubscriptionGeoCodeNpaResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionNpa">
+<wsdl:input name="ReserveSubscriptionNpaRequest" message="ns0:reserveSubscriptionNpaRequest"/>
+<wsdl:output name="ReserveSubscriptionNpaResponse" message="ns0:reserveSubscriptionNpaResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionWithRsvId">
+<wsdl:input name="ReserveSubscriptionWithRsvIdRequest" message="ns0:reserveSubscriptionWithRsvIdRequest"/>
+<wsdl:output name="ReserveSubscriptionWithRsvIdResponse" message="ns0:reserveSubscriptionWithRsvIdResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="WholesaleActivatePendingSubscriptionV4">
+<wsdl:input name="WholesaleActivatePendingSubscriptionV4Request" message="ns0:wholesaleActivatePendingSubscriptionV4"/>
+<wsdl:output name="WholesaleActivatePendingSubscriptionV4Response" message="ns0:wholesaleActivatePendingSubscriptionV4Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation>
+<wsdl:operation name="WholesaleActivateSubscriptionV4">
+<wsdl:input name="WholesaleActivateSubscriptionV4Request" message="ns0:wholesaleActivateSubscriptionV4"/>
+<wsdl:output name="WholesaleActivateSubscriptionV4Response" message="ns0:wholesaleActivateSubscriptionV4Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation>
+<wsdl:operation name="WholesaleReserveSubscriptionGeoCodeV3">
+<wsdl:input name="WholesaleReserveSubscriptionGeoCodeV3Request" message="ns0:wholesaleReserveSubscriptionGeoCodeV3"/>
+<wsdl:output name="WholesaleReserveSubscriptionGeoCodeV3Response" message="ns0:wholesaleReserveSubscriptionGeoCodeV3Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation>
+<wsdl:operation name="WholesaleReserveSubscriptionV3">
+<wsdl:input name="WholesaleReserveSubscriptionV3Request" message="ns0:wholesaleReserveSubscriptionV3"/>
+<wsdl:output name="WholesaleReserveSubscriptionV3Response" message="ns0:wholesaleReserveSubscriptionV3Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleSubscriptionBinding" type="ns0:WholesaleSubscriptionPortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="ActivatePendingSubscription">
+<soap11:operation soapAction="activatePendingSubscription" style="document"/>
+<wsdl:input name="ActivatePendingSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivatePendingSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ActivateSubscription">
+<soap11:operation soapAction="activateSubscription" style="document"/>
+<wsdl:input name="ActivateSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivateSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionMsid">
+<soap11:operation soapAction="activateSubscriptionMsid" style="document"/>
+<wsdl:input name="ActivateSubscriptionMsidRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivateSubscriptionMsidResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionNpa">
+<soap11:operation soapAction="activateSubscriptionNpa" style="document"/>
+<wsdl:input name="ActivateSubscriptionNpaRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivateSubscriptionNpaResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionNpaWithRsvId">
+<soap11:operation soapAction="activateSubscriptionNpaWithRsvId" style="document"/>
+<wsdl:input name="ActivateSubscriptionNpaWithRsvIdRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivateSubscriptionNpaWithRsvIdResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ActivateSubscriptionWithRsvId">
+<soap11:operation soapAction="activateSubscriptionWithRsvId" style="document"/>
+<wsdl:input name="ActivateSubscriptionWithRsvIdRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivateSubscriptionWithRsvIdResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ReserveSubscription">
+<soap11:operation soapAction="reserveSubscription" style="document"/>
+<wsdl:input name="ReserveSubscriptionRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ReserveSubscriptionResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionGeoCode">
+<soap11:operation soapAction="reserveSubscriptionGeoCode" style="document"/>
+<wsdl:input name="ReserveSubscriptionGeoCodeRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ReserveSubscriptionGeoCodeResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionGeoCodeNpa">
+<soap11:operation soapAction="reserveSubscriptionGeoCodeNpa" style="document"/>
+<wsdl:input name="ReserveSubscriptionGeoCodeNpaRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ReserveSubscriptionGeoCodeNpaResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionNpa">
+<soap11:operation soapAction="reserveSubscriptionNpa" style="document"/>
+<wsdl:input name="ReserveSubscriptionNpaRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ReserveSubscriptionNpaResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ReserveSubscriptionWithRsvId">
+<soap11:operation soapAction="reserveSubscriptionWithRsvId" style="document"/>
+<wsdl:input name="ReserveSubscriptionWithRsvIdRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ReserveSubscriptionWithRsvIdResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleActivatePendingSubscriptionV4">
+<soap11:operation soapAction="WholesaleActivatePendingSubscriptionV4" style="document"/>
+<wsdl:input name="WholesaleActivatePendingSubscriptionV4Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleActivatePendingSubscriptionV4Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleActivateSubscriptionV4">
+<soap11:operation soapAction="WholesaleActivateSubscriptionV4" style="document"/>
+<wsdl:input name="WholesaleActivateSubscriptionV4Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleActivateSubscriptionV4Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleReserveSubscriptionGeoCodeV3">
+<soap11:operation soapAction="wholesaleReserveSubscriptionGeoCodeV3" style="document"/>
+<wsdl:input name="WholesaleReserveSubscriptionGeoCodeV3Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleReserveSubscriptionGeoCodeV3Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleReserveSubscriptionV3">
+<soap11:operation soapAction="wholesaleReserveSubscriptionV3" style="document"/>
+<wsdl:input name="WholesaleReserveSubscriptionV3Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleReserveSubscriptionV3Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleSubscriptionService">
+<wsdl:port name="WholesaleSubscriptionPort" binding="ns0:WholesaleSubscriptionBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleSubscriptionService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleSwapSplitService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleSwapSplitService/v1.wsdl
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleSwapSplit/v1/WholesaleSwapSplit.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleSwapSplit/v1/WholesaleSwapSplit.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetails.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleSwapDevice/v2/wholesaleSwapDeviceV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="faultmessage">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetails.xsd"/></wsdl:message>
+<wsdl:message name="faultmessageV2">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="splitNpaMdnRequest">
+<wsdl:part name="body" element="xsns:splitNpaMdn" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="splitNpaMdnResponse">
+<wsdl:part name="body" element="xsns:splitNpaMdnResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapEsnRequest">
+<wsdl:part name="body" element="xsns:swapEsn" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapEsnResponse">
+<wsdl:part name="body" element="xsns:swapEsnResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapMdnRequest">
+<wsdl:part name="body" element="xsns:swapMdn" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapMdnResponse">
+<wsdl:part name="body" element="xsns:swapMdnResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapMdnWithReserveIdRequest">
+<wsdl:part name="body" element="xsns:swapMdnWithReserveId" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapMdnWithReserveIdResponse">
+<wsdl:part name="body" element="xsns:swapMdnWithReserveIdResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapMsidRequest">
+<wsdl:part name="body" element="xsns:swapMsid" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="swapMsidResponse">
+<wsdl:part name="body" element="xsns:swapMsidResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleSwapSplit/v1/SwapSplitEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleSwapDeviceV2">
+<wsdl:part name="body" element="xsns:wholesaleSwapDeviceV2" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleSwapDevice/v2/wholesaleSwapDeviceV2.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleSwapDeviceV2Response">
+<wsdl:part name="body" element="xsns:wholesaleSwapDeviceV2Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleSwapDevice/v2/wholesaleSwapDeviceV2.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleSwapSplitPortType">
+<wsdl:operation name="SplitNpaMdn">
+<wsdl:input name="SplitNpaMdnRequest" message="ns0:splitNpaMdnRequest"/>
+<wsdl:output name="SplitNpaMdnResponse" message="ns0:splitNpaMdnResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="SwapEsn" parameterOrder="body">
+<wsdl:input name="SwapEsnRequest" message="ns0:swapEsnRequest"/>
+<wsdl:output name="SwapEsnResponse" message="ns0:swapEsnResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="SwapMdn">
+<wsdl:input name="SwapMdnRequest" message="ns0:swapMdnRequest"/>
+<wsdl:output name="SwapMdnResponse" message="ns0:swapMdnResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="SwapMdnWithReserveId">
+<wsdl:input name="SwapMdnWithReserveIdRequest" message="ns0:swapMdnWithReserveIdRequest"/>
+<wsdl:output name="SwapMdnWithReserveIdResponse" message="ns0:swapMdnWithReserveIdResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="SwapMsid">
+<wsdl:input name="SwapMsidRequest" message="ns0:swapMsidRequest"/>
+<wsdl:output name="SwapMsidResponse" message="ns0:swapMsidResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="WholesaleSwapDeviceV2">
+<wsdl:input name="WholesaleSwapDeviceV2Request" message="ns0:wholesaleSwapDeviceV2"/>
+<wsdl:output name="WholesaleSwapDeviceV2Response" message="ns0:wholesaleSwapDeviceV2Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleSwapSplitBinding" type="ns0:WholesaleSwapSplitPortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="SplitNpaMdn">
+<soap11:operation soapAction="splitNpaMdn" style="document"/>
+<wsdl:input name="SplitNpaMdnRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="SplitNpaMdnResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="SwapEsn">
+<soap11:operation soapAction="swapEsn" style="document"/>
+<wsdl:input name="SwapEsnRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="SwapEsnResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="SwapMdn">
+<soap11:operation soapAction="swapMdn" style="document"/>
+<wsdl:input name="SwapMdnRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="SwapMdnResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="SwapMdnWithReserveId">
+<soap11:operation soapAction="swapMdnWithReserveId" style="document"/>
+<wsdl:input name="SwapMdnWithReserveIdRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="SwapMdnWithReserveIdResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="SwapMsid">
+<soap11:operation soapAction="swapMsid" style="document"/>
+<wsdl:input name="SwapMsidRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="SwapMsidResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleSwapDeviceV2">
+<soap11:operation soapAction="WholesaleSwapDeviceV2" style="document"/>
+<wsdl:input name="WholesaleSwapDeviceV2Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleSwapDeviceV2Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleSwapSplit">
+<wsdl:port name="WholesaleSwapSplitPort" binding="ns0:WholesaleSwapSplitBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleSwapSplitService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>

--- a/spec/fixtures/wsdl/WholesaleWnpService/v1.wsdl
+++ b/spec/fixtures/wsdl/WholesaleWnpService/v1.wsdl
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap11="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:wsp200409="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsp200607="http://www.w3.org/2006/07/ws-policy" xmlns:ns0="http://integration.sprint.com/eai/services/WholesaleWnp/v1/WholesaleWnp.wsdl" targetNamespace="http://integration.sprint.com/eai/services/WholesaleWnp/v1/WholesaleWnp.wsdl">
+<wsdl:types xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema>
+<xsd:import schemaLocation="v1.xsd2.xsd" namespace="http://integration.sprint.com/common/ErrorDetails.xsd"/>
+<xsd:import schemaLocation="v1.xsd3.xsd" namespace="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/>
+<xsd:import schemaLocation="v1.xsd4.xsd" namespace="http://integration.sprint.com/common/header/WSMessageHeader/v2"/>
+<xsd:import schemaLocation="v1.xsd5.xsd" namespace="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptionWithPortIn/v4/wholesaleActivateSubscriptionWithPortInV4.xsd"/>
+<xsd:import schemaLocation="v1.xsd6.xsd" namespace="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></xsd:schema></wsdl:types>
+<wsdl:message name="activateSubscriptionWithPortInRequest">
+<wsdl:part name="body" element="xsns:activateSubscriptionWithPortIn" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="activateSubscriptionWithPortInResponse">
+<wsdl:part name="body" element="xsns:activateSubscriptionWithPortInResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="cancelPortRequest">
+<wsdl:part name="body" element="xsns:cancelPort" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="cancelPortResponse">
+<wsdl:part name="body" element="xsns:cancelPortResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="changePortInDueDateTimeRequest">
+<wsdl:part name="body" element="xsns:changePortInDueDateTime" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="changePortInDueDateTimeResponse">
+<wsdl:part name="body" element="xsns:changePortInDueDateTimeResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="faultmessage">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetails.xsd"/></wsdl:message>
+<wsdl:message name="faultmessageV2">
+<wsdl:part name="body" element="xsns:errorDetailItem" xmlns:xsns="http://integration.sprint.com/common/ErrorDetailsV2.xsd"/></wsdl:message>
+<wsdl:message name="modifyPortInRequest">
+<wsdl:part name="body" element="xsns:modifyPortIn" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="modifyPortInResponse">
+<wsdl:part name="body" element="xsns:modifyPortInResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="portInSwapMdnRequest">
+<wsdl:part name="body" element="xsns:portInSwapMdn" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="portInSwapMdnResponse">
+<wsdl:part name="body" element="xsns:portInSwapMdnResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="preValidatePortRequest">
+<wsdl:part name="body" element="xsns:preValidatePort" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="preValidatePortResponse">
+<wsdl:part name="body" element="xsns:preValidatePortResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryPendingResellerPortInsRequest">
+<wsdl:part name="body" element="xsns:queryPendingResellerPortIns" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="queryPendingResellerPortInsResponse">
+<wsdl:part name="body" element="xsns:queryPendingResellerPortInsResponse" xmlns:xsns="http://integration.sprint.com/interfaces/WholesaleWnp/v1/PortEnvelope.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleActivateSubscriptionWithPortInV4">
+<wsdl:part name="body" element="xsns:wholesaleActivateSubscriptionWithPortInV4" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptionWithPortIn/v4/wholesaleActivateSubscriptionWithPortInV4.xsd"/></wsdl:message>
+<wsdl:message name="wholesaleActivateSubscriptionWithPortInV4Response">
+<wsdl:part name="body" element="xsns:wholesaleActivateSubscriptionWithPortInV4Response" xmlns:xsns="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptionWithPortIn/v4/wholesaleActivateSubscriptionWithPortInV4.xsd"/></wsdl:message>
+<wsdl:message name="WsMessageHeader">
+<wsdl:part name="head" element="xsns:wsMessageHeader" xmlns:xsns="http://integration.sprint.com/common/header/WSMessageHeader/v2"/></wsdl:message>
+<wsdl:portType name="WholesaleWnpPortType">
+<wsdl:operation name="ActivateSubscriptionWithPortIn">
+<wsdl:input name="ActivateSubscriptionWithPortInRequest" message="ns0:activateSubscriptionWithPortInRequest"/>
+<wsdl:output name="ActivateSubscriptionWithPortInResponse" message="ns0:activateSubscriptionWithPortInResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="CancelPort">
+<wsdl:input name="CancelPortRequest" message="ns0:cancelPortRequest"/>
+<wsdl:output name="CancelPortResponse" message="ns0:cancelPortResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ChangePortInDueDateTime">
+<wsdl:input name="ChangePortInDueDateTimeRequest" message="ns0:changePortInDueDateTimeRequest"/>
+<wsdl:output name="ChangePortInDueDateTimeResponse" message="ns0:changePortInDueDateTimeResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="ModifyPortIn">
+<wsdl:input name="ModifyPortInRequest" message="ns0:modifyPortInRequest"/>
+<wsdl:output name="ModifyPortInResponse" message="ns0:modifyPortInResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="PortInSwapMdn">
+<wsdl:input name="PortInSwapMdnRequest" message="ns0:portInSwapMdnRequest"/>
+<wsdl:output name="PortInSwapMdnResponse" message="ns0:portInSwapMdnResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="PreValidatePort">
+<wsdl:input name="PreValidatePortRequest" message="ns0:preValidatePortRequest"/>
+<wsdl:output name="PreValidatePortResponse" message="ns0:preValidatePortResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="QueryPendingResellerPortIns">
+<wsdl:input name="QueryPendingResellerPortInsRequest" message="ns0:queryPendingResellerPortInsRequest"/>
+<wsdl:output name="QueryPendingResellerPortInsResponse" message="ns0:queryPendingResellerPortInsResponse"/>
+<wsdl:fault name="fault" message="ns0:faultmessage"/></wsdl:operation>
+<wsdl:operation name="WholesaleActivateSubscriptionWithPortInV4">
+<wsdl:input name="WholesaleActivateSubscriptionWithPortInV4Request" message="ns0:wholesaleActivateSubscriptionWithPortInV4"/>
+<wsdl:output name="WholesaleActivateSubscriptionWithPortInV4Response" message="ns0:wholesaleActivateSubscriptionWithPortInV4Response"/>
+<wsdl:fault name="fault" message="ns0:faultmessageV2"/></wsdl:operation></wsdl:portType>
+<wsdl:binding name="WholesaleWnpBinding" type="ns0:WholesaleWnpPortType">
+<soap11:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+<wsdl:operation name="ActivateSubscriptionWithPortIn">
+<soap11:operation soapAction="activateSubscriptionWithPortIn" style="document"/>
+<wsdl:input name="ActivateSubscriptionWithPortInRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ActivateSubscriptionWithPortInResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="CancelPort">
+<soap11:operation soapAction="cancelPort" style="document"/>
+<wsdl:input name="CancelPortRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="CancelPortResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ChangePortInDueDateTime">
+<soap11:operation soapAction="changePortInDueDateTime" style="document"/>
+<wsdl:input name="ChangePortInDueDateTimeRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ChangePortInDueDateTimeResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="ModifyPortIn">
+<soap11:operation soapAction="modifyPortIn" style="document"/>
+<wsdl:input name="ModifyPortInRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="ModifyPortInResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="PortInSwapMdn">
+<soap11:operation soapAction="portInSwapMdn" style="document"/>
+<wsdl:input name="PortInSwapMdnRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="PortInSwapMdnResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="PreValidatePort">
+<soap11:operation soapAction="preValidatePort" style="document"/>
+<wsdl:input name="PreValidatePortRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="PreValidatePortResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="QueryPendingResellerPortIns">
+<soap11:operation soapAction="queryPendingResellerPortIns" style="document"/>
+<wsdl:input name="QueryPendingResellerPortInsRequest">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="QueryPendingResellerPortInsResponse">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation>
+<wsdl:operation name="WholesaleActivateSubscriptionWithPortInV4">
+<soap11:operation soapAction="WholesaleActivateSubscriptionWithPortInV4" style="document"/>
+<wsdl:input name="WholesaleActivateSubscriptionWithPortInV4Request">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:input>
+<wsdl:output name="WholesaleActivateSubscriptionWithPortInV4Response">
+<soap11:body use="literal"/>
+<soap11:header message="ns0:WsMessageHeader" part="head" use="literal"/></wsdl:output>
+<wsdl:fault name="fault">
+<soap11:fault name="fault" use="literal"/></wsdl:fault></wsdl:operation></wsdl:binding>
+<wsdl:service name="WholesaleWnpService">
+<wsdl:port name="WholesaleWnpPort" binding="ns0:WholesaleWnpBinding">
+<soap11:address location="https://webservicesgateway.sprint.com:444/services/mvno/WholesaleWnpService/v1"/></wsdl:port></wsdl:service></wsdl:definitions>


### PR DESCRIPTION
By caching the WSDL documents the Sprint driver no longer needs to check the remote wsdl service, greatly increasing its speed and minimizing the frequent Bad Gateway (502) responses from the service.