### PR TITLE
remove code introduced on pull req 53

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (0.2.19)
+    conduit-sprint (0.2.20)
       StreetAddress
       conduit (~> 0.6.0)
       excon (~> 0.44.4)

--- a/lib/conduit/sprint/actions/base.rb
+++ b/lib/conduit/sprint/actions/base.rb
@@ -58,7 +58,7 @@ module Conduit::Driver::Sprint
     def perform_request
       client    = Savon.client(wsdl: wsdl, raise_errors: false)
       response  = client.call(self.class.operation, xml: signed_soap_xml)
-      parser.new(response.xml, @options)
+      parser.new(response.xml)
     end
 
     def soap_xml

--- a/lib/conduit/sprint/parsers/base.rb
+++ b/lib/conduit/sprint/parsers/base.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 module Conduit::Driver::Sprint
   module Parser
     class Base < Conduit::Core::Parser
-      attr_accessor :xml, :options
+      attr_accessor :xml
 
       def self.attribute(attr_name, &block)
         block ||= lambda do
@@ -12,9 +12,8 @@ module Conduit::Driver::Sprint
         super(attr_name, &block)
       end
 
-      def initialize(xml, options)
+      def initialize(xml)
         self.xml = xml
-        self.options = options
       end
 
       def root

--- a/lib/conduit/sprint/parsers/change_device.rb
+++ b/lib/conduit/sprint/parsers/change_device.rb
@@ -9,11 +9,6 @@ module Conduit::Driver::Sprint
       content_for '//serialNumber'
     end
 
-    attribute :iccid do
-      # Sprint does not pass back the iccid, let take it from the request options
-      @options[:iccid]
-    end
-
     attribute :msl do
       content_for '//masterSubsidyLock'
     end

--- a/lib/conduit/sprint/parsers/query_port_status.rb
+++ b/lib/conduit/sprint/parsers/query_port_status.rb
@@ -16,7 +16,7 @@ module Conduit::Driver::Sprint
       @message_code
     end
 
-    def initialize(xml, options)
+    def initialize(xml)
       super
       set_response_attributes
     end

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '0.2.19'
+    VERSION = '0.2.20'
   end
 end

--- a/spec/conduit/sprint/actions/change_device_spec.rb
+++ b/spec/conduit/sprint/actions/change_device_spec.rb
@@ -49,7 +49,6 @@ describe ChangeDevice do
     its(:response_status)   { should eq 'success' }
     its(:nid)               { should eq nid }
     its(:mdn)               { should eq mdn }
-    its(:iccid)             { should eq nil }
     its(:response_errors)   { should be_empty }
     its(:serializable_hash) { should_not eq be_empty }
   end
@@ -64,7 +63,6 @@ describe ChangeDevice do
     its(:response_status)   { should eq 'success' }
     its(:nid)               { should eq nid }
     its(:mdn)               { should eq mdn }
-    its(:iccid)             { should eq iccid }
     its(:response_errors)   { should be_empty }
     its(:serializable_hash) { should_not eq be_empty }
   end


### PR DESCRIPTION
Need to remove code from pull req 53. Was causing errors in reactor.
Reason is, reactor uses conduit parsers to parse the content for sprint
and fusion. Conduit parsers cannot expect a options attribute since it
only applies to conduit-sprint and not fusion.