### PR TITLE
Use !zip.blank? rather than !!zip to filter check_coverage params

### DIFF
--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '0.3.3'
+    VERSION = '0.3.4'
   end
 end

--- a/lib/conduit/sprint/views/check_coverage.erb
+++ b/lib/conduit/sprint/views/check_coverage.erb
@@ -1,9 +1,9 @@
 <sub:queryCsa>
-<% if !!zip %>
+<% if !zip.blank? %>
 <sub:geoCode>Zip</sub:geoCode>
 <sub:zip>
 <sub:uspsPostalCd><%= zip %></sub:uspsPostalCd>
-<% if !!zip4 %>
+<% if !zip4.blank? %>
 <sub:uspsPostalCdExtension><%= zip4 %></sub:uspsPostalCdExtension>
 <% end %>
 </sub:zip>

--- a/spec/conduit/sprint/actions/check_coverage_spec.rb
+++ b/spec/conduit/sprint/actions/check_coverage_spec.rb
@@ -6,7 +6,7 @@ describe CheckCoverage do
   end
 
   let(:check_coverage_city_state) do
-    CheckCoverage.new(credentials.merge(city: 'Palm Beach', state: 'FL'))
+    CheckCoverage.new(credentials.merge(city: 'Palm Beach', state: 'FL', zip: ''))
   end
 
   let(:unsigned_zipcode_soap) do
@@ -23,7 +23,7 @@ describe CheckCoverage do
 
   describe 'soap_xml_zip' do
     subject { check_coverage_zip.soap_xml }
-    it      { should eq unsigned_zipcode_soap }
+    it      { should eq unsigned_zipcode_soap.strip }
   end
 
   describe 'signed_soap_xml_zip' do

--- a/spec/fixtures/requests/check_coverage/unsigned_zipcode_soap.xml
+++ b/spec/fixtures/requests/check_coverage/unsigned_zipcode_soap.xml
@@ -22,5 +22,6 @@ xmlns:sub="http://integration.sprint.com/interfaces/QueryCsa/v1/QueryCsaEnvelope
 <sub:uspsPostalCd>33415</sub:uspsPostalCd>
 <sub:uspsPostalCdExtension>5555</sub:uspsPostalCdExtension>
 </sub:zip>
-</sub:queryCsa></soapenv:Body>
+</sub:queryCsa>
+</soapenv:Body>
 </soapenv:Envelope>


### PR DESCRIPTION
!zip.blank? filters out both ```nil``` as well as empty strings ```''```.  The presence of an empty string causes the view to assemble a zip-code coverage check rather than a city/state check.