### PR TITLE
remove message hash and use validation message from sprint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (0.3.11)
+    conduit-sprint (0.3.12)
       StreetAddress
       conduit (~> 0.6.0)
       excon (~> 0.44.4)

--- a/lib/conduit/sprint/parsers/query_device_info.rb
+++ b/lib/conduit/sprint/parsers/query_device_info.rb
@@ -8,23 +8,6 @@ module Conduit::Driver::Sprint
       '1' => 'Available'
     }
 
-    NOT_AVAILABLE_CODES = {
-      '1'  => 'Stolen',
-      '2'  => 'In Use',
-      '3'  => 'Fraudulent',
-      '4'  => 'Not in database',
-      '5'  => 'Owner = SPCS',
-      '6'  => 'Pre-paid, unprovisionable',
-      '7'  => 'In use with another MVNO',
-      '8'  => 'Lost in CLWR',
-      '9'  => 'Stolen in CLWR',
-      '10' => 'Broken in CLWR',
-      '11' => 'Blacklisted in CLWR',
-      '12' => 'Reported lost/stolen by another carrier',
-      '13' => 'Phone owner account ID mismatch Financial Eligiblity Date (FED) not met',
-      '99' => 'Not available for activation'
-    }
-
     attribute :model_name do
       content_for '//modelName'
     end
@@ -85,16 +68,8 @@ module Conduit::Driver::Sprint
       content_for '//uiccNotAvailableReasonCode'
     end
 
-    attribute :uicc_not_available_reason_message do
-      NOT_AVAILABLE_CODES[content_for '//uiccNotAvailableReasonCode']
-    end
-
     attribute :not_available_reason_code do
       content_for '//notAvailableReasonCode'
-    end
-
-    attribute :not_available_reason_message do
-      NOT_AVAILABLE_CODES[content_for '//notAvailableReasonCode']
     end
 
     attribute :device_serial_number do

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '0.3.11'
+    VERSION = '0.3.12'
   end
 end

--- a/spec/conduit/sprint/actions/query_device_info_spec.rb
+++ b/spec/conduit/sprint/actions/query_device_info_spec.rb
@@ -71,12 +71,10 @@ describe QueryDeviceInfo do
        :model_number                      => "SPHL720TB1",
        :manufacturer_name                 => "SAMSUNG",
        :not_available_reason_code         => "0",
-       :not_available_reason_message      => nil,
        :uicc_availability_code            => "1",
        :uicc_availability_message         => "Available",
        :uicc_compatibility                => "Y",
        :uicc_not_available_reason_code    => "0",
-       :uicc_not_available_reason_message => nil,
        :uicc_type                         => "U",
        :validation_message                => "Device is valid and cleared for use",
       }


### PR DESCRIPTION
For validate device v1 we needed to translate the message, this is no
longer with sprint version 2.