### PR TITLE
Provide uicc not available reason in addition to the code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (1.0.1)
+    conduit-sprint (1.0.2)
       StreetAddress
       conduit (~> 0.6.0)
       excon (~> 0.44.4)
@@ -21,12 +21,12 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    aws-sdk (2.1.12)
-      aws-sdk-resources (= 2.1.12)
-    aws-sdk-core (2.1.12)
+    aws-sdk (2.1.17)
+      aws-sdk-resources (= 2.1.17)
+    aws-sdk-core (2.1.17)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.12)
-      aws-sdk-core (= 2.1.12)
+    aws-sdk-resources (2.1.17)
+      aws-sdk-core (= 2.1.17)
     builder (3.2.2)
     conduit (0.6.2)
       activesupport
@@ -95,4 +95,4 @@ DEPENDENCIES
   shoulda-matchers
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/lib/conduit/sprint/parsers/query_device_info.rb
+++ b/lib/conduit/sprint/parsers/query_device_info.rb
@@ -64,6 +64,17 @@ module Conduit::Driver::Sprint
       'R' => 'DEVICES WITH PRL LIMITATIONS',
     }
 
+    UICC_NOT_AVAILABLE_REASON_CODES = {
+      '0' => 'Available',
+      '1' => 'Stolen',
+      '2' => 'In use',
+      '3' => 'Fraudulent',
+      '4' => 'Not in database',
+      '5' => 'Reseller Partner ID is not correct',
+      '6' => 'Pre-paid unprovisionable',
+      '99' => 'Not available for activation'
+    }
+
     attribute :activation_status do
       content_for '//activationStatus'
     end
@@ -170,6 +181,10 @@ module Conduit::Driver::Sprint
 
     attribute :uicc_not_available_reason_code do
       content_for '//uiccNotAvailableReasonCode'
+    end
+
+    attribute :uicc_not_available_reason_message do
+      UICC_NOT_AVAILABLE_REASON_CODES[content_for '//uiccNotAvailableReasonCode']
     end
 
     attribute :not_available_reason_code do

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/spec/conduit/sprint/actions/query_device_info_spec.rb
+++ b/spec/conduit/sprint/actions/query_device_info_spec.rb
@@ -95,6 +95,7 @@ describe QueryDeviceInfo do
        :uicc_availability_message            => "Available",
        :uicc_compatibility                   => "Y",
        :uicc_not_available_reason_code       => "0",
+       :uicc_not_available_reason_message    => "Available",
        :uicc_type                            => "U",
        :uicc_type_description                => "Removable USIM",
        :uicc_compatibility_description       => "Transceiver and UICC are compatible together",


### PR DESCRIPTION
Added uicc_not_available_reason_message and map uicc_not_available_reason_code to the documented statuses available from Sprint.