### PR TITLE
strip street direction on address

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (1.0.2)
+    conduit-sprint (1.0.3)
       StreetAddress
       conduit (~> 0.6.0)
       excon (~> 0.44.4)

--- a/lib/conduit/sprint/decorators/activate_port_decorator.rb
+++ b/lib/conduit/sprint/decorators/activate_port_decorator.rb
@@ -9,5 +9,10 @@ module Conduit::Sprint::Decorators
         (first_name + ' ' + last_name).strip
       end
     end
+
+    def street_direction_ind
+      return if street_direction.blank?
+      street_direction.gsub(/[^a-z]/i, '')
+    end
   end
 end

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end

--- a/lib/conduit/sprint/views/activate_port.erb
+++ b/lib/conduit/sprint/views/activate_port.erb
@@ -13,7 +13,7 @@
 </sub:nameInfo>
 <sub:billStreetNumber><%= street_number %></sub:billStreetNumber>
 <sub:billStreetName><%= street_name %></sub:billStreetName>
-<sub:billStreetDirectionIndicator><%= street_direction %></sub:billStreetDirectionIndicator>
+<sub:billStreetDirectionIndicator><%= street_direction_ind %></sub:billStreetDirectionIndicator>
 <sub:billCityName><%= city %></sub:billCityName>
 <sub:billStateCode><%= state %></sub:billStateCode>
 <sub:zip>

--- a/spec/conduit/sprint/actions/activate_port_spec.rb
+++ b/spec/conduit/sprint/actions/activate_port_spec.rb
@@ -34,7 +34,7 @@ describe ActivatePort do
     let(:port_attributes) do
       credentials.merge(nid: '12345678901', mdn: '5555555555', first_name: 'test', last_name: 'tester',
                     service_codes: ['TESTNVM', 'TESTPMVM', 'TESTINTCL'],
-                    city: 'city', state: 'state', zip: '99999', address1: '123 Test', csa: 'MIAWPB561',
+                    city: 'city', state: 'state', zip: '99999', address1: '123 N. Test', csa: 'MIAWPB561',
                     carrier_account: '999999', plan_code: 'TESTPLAN')
     end
 
@@ -50,7 +50,7 @@ describe ActivatePort do
     let(:port_attributes) do
       credentials.merge(nid: '12345678901', mdn: '5555555555', first_name: 'test', last_name: 'tester',
                     service_codes: ['TESTNVM', 'TESTPMVM', 'TESTINTCL'],
-                    city: 'city', state: 'state', zip: '99999', address1: '123 Test St', csa: 'MIAWPB561',
+                    city: 'city', state: 'state', zip: '99999', address1: '123 N. Test St', csa: 'MIAWPB561',
                     carrier_account: '999999', plan_code: 'TESTPLAN')
     end
 
@@ -66,7 +66,7 @@ describe ActivatePort do
     let(:port_attributes) do
       credentials.merge(nid: '12345678901', mdn: '5555555555',
                     service_codes: ['TESTNVM', 'TESTPMVM', 'TESTINTCL'],
-                    city: 'city', state: 'state', zip: '99999', address1: '123 Test St', csa: 'MIAWPB561',
+                    city: 'city', state: 'state', zip: '99999', address1: '123 N. Test St', csa: 'MIAWPB561',
                     carrier_account: '999999', plan_code: 'TESTPLAN')
     end
 
@@ -133,6 +133,13 @@ describe ActivatePort do
   end
 
   context 'an activate port with out csa should fetch a csa' do
+    let(:port_attributes) do
+      credentials.merge(nid: '12345678901', first_name: 'test', last_name: 'tester', mdn: '5555555555',
+                    service_codes: ['TESTNVM', 'TESTPMVM', 'TESTINTCL'], authorized_by: 'customer',
+                    city: 'city', state: 'state', zip: '99999', address1: '123 N. Test St', csa: 'MIAWPB561',
+                    carrier_account: '999999', plan_code: 'TESTPLAN', ssn: '')
+    end
+
     let(:validate_port) do
       File.read('./spec/fixtures/requests/activate_port/unsigned_validate_port_soap.xml')
     end

--- a/spec/fixtures/requests/activate_port/unsigned_no_authorized_by_soap.xml
+++ b/spec/fixtures/requests/activate_port/unsigned_no_authorized_by_soap.xml
@@ -27,7 +27,7 @@ xmlns:sub="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptio
 </sub:nameInfo>
 <sub:billStreetNumber>123</sub:billStreetNumber>
 <sub:billStreetName>Test St</sub:billStreetName>
-<sub:billStreetDirectionIndicator></sub:billStreetDirectionIndicator>
+<sub:billStreetDirectionIndicator>N</sub:billStreetDirectionIndicator>
 <sub:billCityName>city</sub:billCityName>
 <sub:billStateCode>state</sub:billStateCode>
 <sub:zip>

--- a/spec/fixtures/requests/activate_port/unsigned_no_first_last_name_soap.xml
+++ b/spec/fixtures/requests/activate_port/unsigned_no_first_last_name_soap.xml
@@ -27,7 +27,7 @@ xmlns:sub="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptio
 </sub:nameInfo>
 <sub:billStreetNumber>123</sub:billStreetNumber>
 <sub:billStreetName>Test St</sub:billStreetName>
-<sub:billStreetDirectionIndicator></sub:billStreetDirectionIndicator>
+<sub:billStreetDirectionIndicator>N</sub:billStreetDirectionIndicator>
 <sub:billCityName>city</sub:billCityName>
 <sub:billStateCode>state</sub:billStateCode>
 <sub:zip>

--- a/spec/fixtures/requests/activate_port/unsigned_no_street_type_soap.xml
+++ b/spec/fixtures/requests/activate_port/unsigned_no_street_type_soap.xml
@@ -27,7 +27,7 @@ xmlns:sub="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptio
 </sub:nameInfo>
 <sub:billStreetNumber>123</sub:billStreetNumber>
 <sub:billStreetName>Test</sub:billStreetName>
-<sub:billStreetDirectionIndicator></sub:billStreetDirectionIndicator>
+<sub:billStreetDirectionIndicator>N</sub:billStreetDirectionIndicator>
 <sub:billCityName>city</sub:billCityName>
 <sub:billStateCode>state</sub:billStateCode>
 <sub:zip>

--- a/spec/fixtures/requests/activate_port/unsigned_validate_port_soap.xml
+++ b/spec/fixtures/requests/activate_port/unsigned_validate_port_soap.xml
@@ -27,7 +27,7 @@ xmlns:sub="http://integration.sprint.com/interfaces/wholesaleActivateSubscriptio
 </sub:nameInfo>
 <sub:billStreetNumber>123</sub:billStreetNumber>
 <sub:billStreetName>Test St</sub:billStreetName>
-<sub:billStreetDirectionIndicator></sub:billStreetDirectionIndicator>
+<sub:billStreetDirectionIndicator>N</sub:billStreetDirectionIndicator>
 <sub:billCityName>city</sub:billCityName>
 <sub:billStateCode>state</sub:billStateCode>
 <sub:zip>


### PR DESCRIPTION
sprint has a bug where if we send “N.” for directional they will send a
good response but something will die in there system and the request
will really be failed…. :sob:  we need to strip the street direction.