### PR TITLE
Remove spaces and downcase consumer_id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (1.0.7)
+    conduit-sprint (1.0.8)
       StreetAddress
       conduit (~> 0.6.0)
       excon (~> 0.44.4)

--- a/lib/conduit/sprint/actions/add_foreign_device.rb
+++ b/lib/conduit/sprint/actions/add_foreign_device.rb
@@ -10,8 +10,11 @@ module Conduit::Driver::Sprint
 
     def initialize(options = {})
       super
-      # Sprint wants a consumer_id in the api call, its the same as app_user_id
-      @options[:consumer_id] ||= @options[:application_user_id]
+
+      # Sprint wants a consumer_id in the api call, its the same as app_user_id transformed
+      if !@options[:application_user_id].blank?
+        @options[:consumer_id] ||= @options[:application_user_id].delete(' ').downcase
+      end
     end
 
     def test_gateway

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '1.0.7'
+    VERSION = '1.0.8'
   end
 end

--- a/spec/conduit/sprint/actions/add_foreign_device_spec.rb
+++ b/spec/conduit/sprint/actions/add_foreign_device_spec.rb
@@ -40,6 +40,18 @@ describe AddForeignDevice do
     end
   end
 
+  context "when no consumber_id is passed" do
+    before do
+      creds.delete(:consumer_id)
+      creds[:application_user_id] = 'App User Id'
+    end
+
+    it 'should use app user id transformed' do
+      consumer_id = add_foreign_device.attributes_with_values[:consumer_id]
+      expect(consumer_id).to eql 'appuserid'
+    end
+  end
+
   context 'a successful add_foreign_device response is returned' do
     let(:serializable_hash) do
       {


### PR DESCRIPTION
We need to remove spaces and downcase consumer_id when sending to sprint for add_foreign_device api call.

Reason for this is api calls are failing.