### PR TITLE
Use TLSv1.2, not TLSv1

### DIFF
--- a/lib/conduit/sprint/actions/base.rb
+++ b/lib/conduit/sprint/actions/base.rb
@@ -65,7 +65,7 @@ module Conduit::Driver::Sprint
     end
 
     def perform_request
-      client    = Savon.client(wsdl: wsdl, raise_errors: false, ssl_version: :TLSv1)
+      client    = Savon.client(wsdl: wsdl, raise_errors: false, ssl_version: :TLSv1_2)
       response  = client.call(self.class.operation, xml: signed_soap_xml)
       parser.new(response.xml)
     end

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '1.0.8'
+    VERSION = '1.0.9'
   end
 end


### PR DESCRIPTION
From Sprint:
To maintain security standards, Sprint will be migrating from the
current encryption standard for internet and web based traffic, TLS 1.0,
to the current best practice standard, TLS 1.2 by June 30, 2016.

A few notes for the reader:
TLSv1 Was considered insecure after POODLE, in November of 2014.

We added the specific version in June of 2015, because their servers
only supported TLSv1.

June 30, 2016 is also when TLSv1 isn't PCI compliant.

TLSv1 hasn't been a 'current encryption standard for internet and web
based traffic' for at least 5 or 6 years.

Better late then never.