### PR TITLE
Filtering generic "Application processing error" because it's not useful information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sprint (1.2.0)
+    conduit-sprint (1.2.1)
       StreetAddress
       conduit (~> 0.7.0)
       excon (~> 0.44.4)
@@ -21,12 +21,12 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    aws-sdk (2.2.34)
-      aws-sdk-resources (= 2.2.34)
-    aws-sdk-core (2.2.34)
+    aws-sdk (2.2.36)
+      aws-sdk-resources (= 2.2.36)
+    aws-sdk-core (2.2.36)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.34)
-      aws-sdk-core (= 2.2.34)
+    aws-sdk-resources (2.2.36)
+      aws-sdk-core (= 2.2.36)
     builder (3.2.2)
     byebug (8.2.2)
     coderay (1.1.1)

--- a/lib/conduit/sprint/parsers/base.rb
+++ b/lib/conduit/sprint/parsers/base.rb
@@ -51,7 +51,7 @@ module Conduit::Driver::Sprint
           if fault.nil?
             []
           elsif provider_errors.any?
-            normalized_provider_errors
+            prune_generic_errors(normalized_provider_errors)
           else
             [normalized_fault]
           end
@@ -86,6 +86,11 @@ module Conduit::Driver::Sprint
       def normalized_fault
         Conduit::Error.new(message: content_for('faultstring', fault),
           code: content_for('faultcode', fault))
+      end
+
+      def prune_generic_errors(errors)
+        return errors if errors.length == 1
+        errors.reject { |error| error.code == "Server.704" }
       end
     end
   end

--- a/lib/conduit/sprint/version.rb
+++ b/lib/conduit/sprint/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Sprint
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/spec/conduit/sprint/actions/add_foreign_device_spec.rb
+++ b/spec/conduit/sprint/actions/add_foreign_device_spec.rb
@@ -73,8 +73,7 @@ describe AddForeignDevice do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(code: "264", message: "RESKU_INFO_MISSING: Device re-SKU information not found"),
-        Conduit::Error.new(code: "Server.704", message: "Application Processing Error")
+        Conduit::Error.new(code: "264", message: "RESKU_INFO_MISSING: Device re-SKU information not found")
       ]
     end
 

--- a/spec/conduit/sprint/actions/change_device_spec.rb
+++ b/spec/conduit/sprint/actions/change_device_spec.rb
@@ -75,8 +75,7 @@ describe ChangeDevice do
     let(:response_errors) do
       [
         Conduit::Error.new(code: "210820012",
-          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO"),
-        Conduit::Error.new(code: "Server.704", message: "Application processing error")
+          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO")
       ]
     end
 

--- a/spec/conduit/sprint/actions/check_coverage_spec.rb
+++ b/spec/conduit/sprint/actions/check_coverage_spec.rb
@@ -129,9 +129,8 @@ describe CheckCoverage do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(:code=>"210820012",
-          :message=>"The subscriber does not belong to the 2222333344 Major Account/MVNO"),
-        Conduit::Error.new(:code=>"Server.704", :message=>"Application processing error")
+        Conduit::Error.new(code: "210820012",
+          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO")
       ]
     end
 

--- a/spec/conduit/sprint/actions/deactivate_spec.rb
+++ b/spec/conduit/sprint/actions/deactivate_spec.rb
@@ -43,9 +43,8 @@ describe Deactivate do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(:code=>"210820012",
-          :message=>"The subscriber does not belong to the 2222333344 Major Account/MVNO"),
-        Conduit::Error.new(:code=>"Server.704", :message=>"Application processing error")
+        Conduit::Error.new(code: "210820012",
+          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO")
       ]
     end
 

--- a/spec/conduit/sprint/actions/hotline_spec.rb
+++ b/spec/conduit/sprint/actions/hotline_spec.rb
@@ -43,8 +43,8 @@ describe Hotline do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(:code=>"210820012", :message=>"The subscriber does not belong to the 2222333344 Major Account/MVNO"),
-        Conduit::Error.new(:code=>"Server.704", :message=>"Application processing error")
+        Conduit::Error.new(code: "210820012",
+          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO")
       ]
     end
 

--- a/spec/conduit/sprint/actions/query_subscription_spec.rb
+++ b/spec/conduit/sprint/actions/query_subscription_spec.rb
@@ -36,8 +36,8 @@ describe QuerySubscription do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(code: '210820012', message: 'The subscriber does not belong to the 2222333344 Major Account/MVNO'),
-        Conduit::Error.new(code: 'Server.704', message: 'Application processing error')
+        Conduit::Error.new(code: '210820012',
+          message: 'The subscriber does not belong to the 2222333344 Major Account/MVNO')
       ]
     end
 

--- a/spec/conduit/sprint/actions/restore_spec.rb
+++ b/spec/conduit/sprint/actions/restore_spec.rb
@@ -43,8 +43,8 @@ describe Restore do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(:code=>"210820012", :message=>"The subscriber does not belong to the 2222333344 Major Account/MVNO"),
-        Conduit::Error.new(:code=>"Server.704", :message=>"Application processing error")
+        Conduit::Error.new(code: "210820012",
+          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO")
       ]
     end
 

--- a/spec/conduit/sprint/actions/suspend_spec.rb
+++ b/spec/conduit/sprint/actions/suspend_spec.rb
@@ -43,8 +43,8 @@ describe Suspend do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(:code=>"210820012", :message=>"The subscriber does not belong to the 2222333344 Major Account/MVNO"),
-        Conduit::Error.new(:code=>"Server.704", :message=>"Application processing error")
+        Conduit::Error.new(code: "210820012",
+          message: "The subscriber does not belong to the 2222333344 Major Account/MVNO")
       ]
     end
 

--- a/spec/conduit/sprint/actions/transfer_ownership_spec.rb
+++ b/spec/conduit/sprint/actions/transfer_ownership_spec.rb
@@ -99,8 +99,7 @@ describe TransferOwnership do
 
     let(:response_errors) do
       [
-        Conduit::Error.new(code: '10', message: 'INVALID_ESN_MEID: esnDec is mandatory'),
-        Conduit::Error.new(code: 'Server.704', message: 'Application processing error')
+        Conduit::Error.new(code: '10', message: 'INVALID_ESN_MEID: esnDec is mandatory')
       ]
     end
 


### PR DESCRIPTION
Just leads to noise.  See:
https://staging.bequickapps.com/logs/carrier/2009578
